### PR TITLE
Fix errors and remove deprecated functions. 

### DIFF
--- a/lib/src/auth/auth_handler.dart
+++ b/lib/src/auth/auth_handler.dart
@@ -17,7 +17,6 @@ class AuthHandler extends Handler {
   final int clientFlags;
   final int maxPacketSize;
   final int characterSet;
-  final bool _ssl;
 
   AuthHandler(
       String this.username,
@@ -27,9 +26,7 @@ class AuthHandler extends Handler {
       int this.clientFlags,
       int this.maxPacketSize,
       int this.characterSet,
-      {bool ssl: false})
-      : this._ssl = false,
-        super(new Logger("AuthHandler"));
+      ) : super(new Logger("AuthHandler"));
 
   List<int> getHash() {
     List<int> hash;

--- a/lib/src/auth/auth_handler.dart
+++ b/lib/src/auth/auth_handler.dart
@@ -36,7 +36,7 @@ class AuthHandler extends Handler {
     if (password == null) {
       hash = <int>[];
     } else {
-      final hashedPassword = sha1.convert(UTF8.encode(password)).bytes;
+      final hashedPassword = sha1.convert(utf8.encode(password)).bytes;
       final doubleHashedPassword = sha1.convert(hashedPassword).bytes;
 
       final bytes = new List<int>.from(scrambleBuffer)
@@ -55,13 +55,13 @@ class AuthHandler extends Handler {
     // calculate the mysql password hash
     var hash = getHash();
 
-    var encodedUsername = username == null ? [] : UTF8.encode(username);
+    var encodedUsername = username == null ? [] : utf8.encode(username);
     var encodedDb;
 
     var size = hash.length + encodedUsername.length + 2 + 32;
     var clientFlags = this.clientFlags;
     if (db != null) {
-      encodedDb = UTF8.encode(db);
+      encodedDb = utf8.encode(db);
       size += encodedDb.length + 1;
       clientFlags |= CLIENT_CONNECT_WITH_DB;
     }

--- a/lib/src/auth/handshake_handler.dart
+++ b/lib/src/auth/handshake_handler.dart
@@ -146,7 +146,7 @@ class HandshakeHandler extends Handler {
               CharacterSet.UTF8,
               new AuthHandler(_user, _password, _db, scrambleBuffer,
                   clientFlags, _maxPacketSize, CharacterSet.UTF8,
-                  ssl: true)));
+                  )));
     }
 
     return new HandlerResponse(

--- a/lib/src/blob.dart
+++ b/lib/src/blob.dart
@@ -18,13 +18,13 @@ class Blob {
 
   /// Create a [Blob] from a [string].
   factory Blob.fromString(String string) =>
-      new Blob.fromBytes(UTF8.encode(string));
+      new Blob.fromBytes(utf8.encode(string));
 
   /// Create a [Blob] from a list of [codeUnits].
   Blob.fromBytes(List<int> codeUnits) : this._codeUnits = codeUnits;
 
   /// Returns the value of the blob as a [String].
-  String toString() => UTF8.decode(_codeUnits, allowMalformed: true);
+  String toString() => utf8.decode(_codeUnits, allowMalformed: true);
 
   /// Returns the value of the blob as a list of code units.
   List<int> toBytes() => _codeUnits;

--- a/lib/src/buffer.dart
+++ b/lib/src/buffer.dart
@@ -162,7 +162,7 @@ class Buffer {
    * Returns the string, without a terminating null.
    */
   String readNullTerminatedString() {
-    return UTF8.decode(readNullTerminatedList());
+    return utf8.decode(readNullTerminatedList());
   }
 
   /**
@@ -175,7 +175,7 @@ class Buffer {
    * Reads a string of the given [length] from the buffer.
    */
   String readString(int length) {
-    String s = UTF8.decode(_list.sublist(_readPos, _readPos + length));
+    String s = utf8.decode(_list.sublist(_readPos, _readPos + length));
     _readPos += length;
     return s;
   }
@@ -272,7 +272,7 @@ class Buffer {
    * Returns a 16-bit integer, read from the buffer
    */
   int readInt16() {
-    int result = _data.getInt16(_readPos, Endianness.LITTLE_ENDIAN);
+    int result = _data.getInt16(_readPos, Endian.little);
     _readPos += 2;
     return result;
   }
@@ -281,7 +281,7 @@ class Buffer {
    * Writes a 16 bit [integer] to the buffer.
    */
   void writeInt16(int integer) {
-    _data.setInt16(_writePos, integer, Endianness.LITTLE_ENDIAN);
+    _data.setInt16(_writePos, integer, Endian.little);
     _writePos += 2;
   }
 
@@ -289,7 +289,7 @@ class Buffer {
    * Returns a 16-bit integer, read from the buffer
    */
   int readUint16() {
-    int result = _data.getUint16(_readPos, Endianness.LITTLE_ENDIAN);
+    int result = _data.getUint16(_readPos, Endian.little);
     _readPos += 2;
     return result;
   }
@@ -298,7 +298,7 @@ class Buffer {
    * Writes a 16 bit [integer] to the buffer.
    */
   void writeUint16(int integer) {
-    _data.setUint16(_writePos, integer, Endianness.LITTLE_ENDIAN);
+    _data.setUint16(_writePos, integer, Endian.little);
     _writePos += 2;
   }
 
@@ -321,7 +321,7 @@ class Buffer {
    * Returns a 32-bit integer, read from the buffer.
    */
   int readInt32() {
-    int val = _data.getInt32(_readPos, Endianness.LITTLE_ENDIAN);
+    int val = _data.getInt32(_readPos,Endian.little);
     _readPos += 4;
     return val;
   }
@@ -330,7 +330,7 @@ class Buffer {
    * Writes a 32 bit [integer] to the buffer.
    */
   void writeInt32(int integer) {
-    _data.setInt32(_writePos, integer, Endianness.LITTLE_ENDIAN);
+    _data.setInt32(_writePos, integer, Endian.little);
     _writePos += 4;
   }
 
@@ -338,7 +338,7 @@ class Buffer {
    * Returns a 32-bit integer, read from the buffer.
    */
   int readUint32() {
-    int val = _data.getUint32(_readPos, Endianness.LITTLE_ENDIAN);
+    int val = _data.getUint32(_readPos, Endian.little);
     _readPos += 4;
     return val;
   }
@@ -347,7 +347,7 @@ class Buffer {
    * Writes a 32 bit [integer] to the buffer.
    */
   void writeUint32(int integer) {
-    _data.setUint32(_writePos, integer, Endianness.LITTLE_ENDIAN);
+    _data.setUint32(_writePos, integer, Endian.little);
     _writePos += 4;
   }
 
@@ -355,7 +355,7 @@ class Buffer {
    * Returns a 64-bit integer, read from the buffer.
    */
   int readInt64() {
-    int val = _data.getInt64(_readPos, Endianness.LITTLE_ENDIAN);
+    int val = _data.getInt64(_readPos, Endian.little);
     _readPos += 8;
     return val;
   }
@@ -364,7 +364,7 @@ class Buffer {
    * Writes a 64 bit [integer] to the buffer.
    */
   void writeInt64(int integer) {
-    _data.setInt64(_writePos, integer, Endianness.LITTLE_ENDIAN);
+    _data.setInt64(_writePos, integer, Endian.little);
     _writePos += 8;
   }
 
@@ -372,7 +372,7 @@ class Buffer {
    * Returns a 64-bit integer, read from the buffer.
    */
   int readUint64() {
-    int val = _data.getUint64(_readPos, Endianness.LITTLE_ENDIAN);
+    int val = _data.getUint64(_readPos, Endian.little);
     _readPos += 8;
     return val;
   }
@@ -381,7 +381,7 @@ class Buffer {
    * Writes a 64 bit [integer] to the buffer.
    */
   void writeUint64(int integer) {
-    _data.setUint64(_writePos, integer, Endianness.LITTLE_ENDIAN);
+    _data.setUint64(_writePos, integer, Endian.little);
     _writePos += 8;
   }
 
@@ -403,24 +403,24 @@ class Buffer {
   }
 
   double readFloat() {
-    double val = _data.getFloat32(_readPos, Endianness.LITTLE_ENDIAN);
+    double val = _data.getFloat32(_readPos, Endian.little);
     _readPos += 4;
     return val;
   }
 
   void writeFloat(double value) {
-    _data.setFloat32(_writePos, value, Endianness.LITTLE_ENDIAN);
+    _data.setFloat32(_writePos, value, Endian.little);
     _writePos += 4;
   }
 
   double readDouble() {
-    double val = _data.getFloat64(_readPos, Endianness.LITTLE_ENDIAN);
+    double val = _data.getFloat64(_readPos, Endian.little);
     _readPos += 8;
     return val;
   }
 
   void writeDouble(double value) {
-    _data.setFloat64(_writePos, value, Endianness.LITTLE_ENDIAN);
+    _data.setFloat64(_writePos, value, Endian.little);
     _writePos += 8;
   }
 

--- a/lib/src/buffered_socket.dart
+++ b/lib/src/buffered_socket.dart
@@ -58,7 +58,7 @@ class BufferedSocket {
     }
   }
 
-  static defaultSocketFactory(host, port) => RawSocket.connect(host, port);
+  static Future<RawSocket> defaultSocketFactory(host, int port) => RawSocket.connect(host, port);
 
   static Future<BufferedSocket> connect(String host, int port,
       {DataReadyHandler onDataReady,

--- a/lib/src/buffered_socket.dart
+++ b/lib/src/buffered_socket.dart
@@ -70,7 +70,7 @@ class BufferedSocket {
     try {
       var socket;
       socket = await socketFactory(host, port);
-      socket.setOption(SocketOption.TCP_NODELAY, true);
+      socket.setOption(SocketOption.tcpNoDelay, true);
 
       var bufferedSocket =
           new BufferedSocket._(socket, onDataReady, onDone, onError, onClosed);
@@ -81,10 +81,11 @@ class BufferedSocket {
     } catch (e) {
       onError(e);
     }
+    return null;
   }
 
   void _onData(RawSocketEvent event) {
-    if (event == RawSocketEvent.READ) {
+    if (event == RawSocketEvent.read) {
       log.fine("READ data");
       if (_readingBuffer == null) {
         log.fine("READ data: no buffer");
@@ -94,14 +95,14 @@ class BufferedSocket {
       } else {
         _readBuffer();
       }
-    } else if (event == RawSocketEvent.READ_CLOSED) {
+    } else if (event == RawSocketEvent.readClosed) {
       log.fine("READ_CLOSED");
       if (this.onClosed != null) {
         this.onClosed();
       }
-    } else if (event == RawSocketEvent.CLOSED) {
+    } else if (event == RawSocketEvent.closed) {
       log.fine("CLOSED");
-    } else if (event == RawSocketEvent.WRITE) {
+    } else if (event == RawSocketEvent.write) {
       log.fine("WRITE data");
       if (_writingBuffer != null) {
         _writeBuffer();
@@ -205,7 +206,7 @@ class BufferedSocket {
         subscription: _subscription, onBadCertificate: (cert) => true);
     log.fine("Socket is secure");
     _socket = socket;
-    _socket.setOption(SocketOption.TCP_NODELAY, true);
+    _socket.setOption(SocketOption.tcpNoDelay, true);
     _subscription = _socket.listen(_onData,
         onError: _onSocketError, onDone: _onSocketDone, cancelOnError: true);
     _socket.writeEventsEnabled = true;

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -282,8 +282,8 @@ class Connection {
       _headerBuffer[1] = (buffer.length & 0xFF00) >> 8;
       _headerBuffer[2] = (buffer.length & 0xFF0000) >> 16;
       _headerBuffer[3] = ++_packetNumber;
-      var encodedHeader = ZLIB.encode(_headerBuffer.list);
-      var encodedBuffer = ZLIB.encode(buffer.list);
+      var encodedHeader = zlib.encode(_headerBuffer.list);
+      var encodedBuffer = zlib.encode(buffer.list);
       _compressedHeaderBuffer
           .writeUint24(encodedHeader.length + encodedBuffer.length);
       _compressedHeaderBuffer.writeByte(++_compressedPacketNumber);

--- a/lib/src/connection_pool_impl.dart
+++ b/lib/src/connection_pool_impl.dart
@@ -221,6 +221,7 @@ class ConnectionPoolImpl extends Object
     } catch (e) {
       releaseReuseThrow(cnx, e);
     }
+    return null;
   }
 
   /**
@@ -329,6 +330,7 @@ class ConnectionPoolImpl extends Object
     } catch (e) {
       releaseReuseThrow(cnx, e);
     }
+    return null;
   }
 
   /**

--- a/lib/src/handlers/quit_handler.dart
+++ b/lib/src/handlers/quit_handler.dart
@@ -16,8 +16,5 @@ class QuitHandler extends Handler {
     return buffer;
   }
 
-  dynamic processResponse(Buffer response) {
-    throw createMySqlProtocolError(
-        "Shouldn't have received a response after sending a QUIT message");
-  }
+  processResponse(Buffer response) => throw createMySqlProtocolError("Shouldn't have received a response after sending a QUIT message");
 }

--- a/lib/src/handlers/use_db_handler.dart
+++ b/lib/src/handlers/use_db_handler.dart
@@ -14,7 +14,7 @@ class UseDbHandler extends Handler {
   UseDbHandler(String this._dbName) : super(new Logger("UseDbHandler"));
 
   Buffer createRequest() {
-    var encoded = UTF8.encode(_dbName);
+    var encoded = utf8.encode(_dbName);
     var buffer = new Buffer(encoded.length + 1);
     buffer.writeByte(COM_INIT_DB);
     buffer.writeList(encoded);

--- a/lib/src/prepared_statements/execute_query_handler.dart
+++ b/lib/src/prepared_statements/execute_query_handler.dart
@@ -173,7 +173,7 @@ class ExecuteQueryHandler extends Handler {
   }
 
   _prepareDouble(value) {
-    return UTF8.encode(value.toString());
+    return utf8.encode(value.toString());
   }
 
   int _measureDouble(value, preparedValue) {
@@ -257,7 +257,7 @@ class ExecuteQueryHandler extends Handler {
   }
 
   _prepareString(value) {
-    return UTF8.encode(value.toString());
+    return utf8.encode(value.toString());
   }
 
   int _measureString(value, preparedValue) {

--- a/lib/src/prepared_statements/prepare_handler.dart
+++ b/lib/src/prepared_statements/prepare_handler.dart
@@ -29,7 +29,7 @@ class PrepareHandler extends Handler {
   PrepareHandler(String this._sql) : super(new Logger("PrepareHandler"));
 
   Buffer createRequest() {
-    var encoded = UTF8.encode(_sql);
+    var encoded = utf8.encode(_sql);
     var buffer = new Buffer(encoded.length + 1);
     buffer.writeByte(COM_STMT_PREPARE);
     buffer.writeList(encoded);

--- a/lib/src/query/query_stream_handler.dart
+++ b/lib/src/query/query_stream_handler.dart
@@ -37,7 +37,7 @@ class QueryStreamHandler extends Handler {
       : super(new Logger("QueryStreamHandler"));
 
   Buffer createRequest() {
-    var encoded = UTF8.encode(_sql);
+    var encoded = utf8.encode(_sql);
     var buffer = new Buffer(encoded.length + 1);
     buffer.writeByte(COM_QUERY);
     buffer.writeList(encoded);

--- a/lib/src/query/standard_data_packet.dart
+++ b/lib/src/query/standard_data_packet.dart
@@ -35,13 +35,13 @@ class StandardDataPacket extends Row {
         case FIELD_TYPE_INT24: // mediumint
         case FIELD_TYPE_LONGLONG: // bigint/serial
         case FIELD_TYPE_LONG: // int
-          var s = UTF8.decode(list);
+          var s = utf8.decode(list);
           values[i] = int.parse(s);
           break;
         case FIELD_TYPE_NEWDECIMAL: // decimal
         case FIELD_TYPE_FLOAT: // float
         case FIELD_TYPE_DOUBLE: // double
-          var s = UTF8.decode(list);
+          var s = utf8.decode(list);
           values[i] = double.parse(s);
           break;
         case FIELD_TYPE_BIT: // bit
@@ -54,11 +54,11 @@ class StandardDataPacket extends Row {
         case FIELD_TYPE_DATE: // date
         case FIELD_TYPE_DATETIME: // datetime
         case FIELD_TYPE_TIMESTAMP: // timestamp
-          var s = UTF8.decode(list);
+          var s = utf8.decode(list);
           values[i] = DateTime.parse(s);
           break;
         case FIELD_TYPE_TIME: // time
-          var s = UTF8.decode(list);
+          var s = utf8.decode(list);
           var parts = s.split(":");
           values[i] = new Duration(
               days: 0,
@@ -68,19 +68,19 @@ class StandardDataPacket extends Row {
               milliseconds: 0);
           break;
         case FIELD_TYPE_YEAR: // year
-          var s = UTF8.decode(list);
+          var s = utf8.decode(list);
           values[i] = int.parse(s);
           break;
         case FIELD_TYPE_STRING: // char/binary/enum/set
         case FIELD_TYPE_VAR_STRING: // varchar/varbinary
-          var s = UTF8.decode(list);
+          var s = utf8.decode(list);
           values[i] = s;
           break;
         case FIELD_TYPE_BLOB: // tinytext/text/mediumtext/longtext/tinyblob/mediumblob/blob/longblob
           values[i] = new Blob.fromBytes(list);
           break;
         case FIELD_TYPE_GEOMETRY: // geometry
-          var s = UTF8.decode(list);
+          var s = utf8.decode(list);
           values[i] = s;
           break;
       }

--- a/lib/src/query_impl.dart
+++ b/lib/src/query_impl.dart
@@ -121,6 +121,7 @@ class QueryImpl extends Object with ConnectionHelpers implements Query {
     } catch (e) {
       releaseReuseThrow(preparedQuery.cnx, e);
     }
+    return null;
   }
 
   /**

--- a/lib/src/results/row.dart
+++ b/lib/src/results/row.dart
@@ -8,5 +8,4 @@ import 'dart:collection';
  * When retrieving a field by name, only fields which are valid Dart
  * identifiers, and which aren't part of the List object, can be used.
  */
-@proxy
 abstract class Row extends ListBase<dynamic> {}

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -29,7 +29,7 @@ class TableDropper {
         await pool.query('drop table $table');
       } catch (e) {
         if (e is MySqlException &&
-            (e as MySqlException).errorNumber == ERROR_UNKNOWN_TABLE) {
+            e.errorNumber == ERROR_UNKNOWN_TABLE) {
           // if it's an unknown table, ignore the error and continue
         } else {
           rethrow;


### PR DESCRIPTION
I've remove all the deprecated function that I could found and fixes this two errors:
```
error: A value of type '(dynamic, dynamic) → dynamic' can't be assigned to a variable of type '(dynamic, int) → Future<RawSocket>'. (invalid_assignment at [sqljocky5] lib\src\buffered_socket.dart:68)
error: Invalid override. The type of 'QuitHandler.processResponse' ('(Buffer) → dynamic') isn't a subtype of 'Handler.processResponse' ('(Buffer) → HandlerResponse'). (strong_mode_invalid_method_override at [sqljocky5] lib\src\handlers\quit_handler.dart:19)
```

My dart version: `2.0.0-dev.69.1`