### PR TITLE
Fix Dart2 Errors

### DIFF
--- a/lib/src/buffered_socket.dart
+++ b/lib/src/buffered_socket.dart
@@ -60,7 +60,7 @@ class BufferedSocket {
     }
   }
 
-  static defaultSocketFactory(host, port) => RawSocket.connect(host, port);
+  static Future<RawSocket> defaultSocketFactory(host, int port) => RawSocket.connect(host, port);
 
   static Future<BufferedSocket> connect(
     String host,


### PR DESCRIPTION
Fix: 
```
buffered_socket.dart:68:36: Error: A value of type '(dynamic, dynamic) → dynamic' can't be assigned to a variable of type '(dynamic, dart.core::int) → dart.async:
Future<dart.io::RawSocket>'.
Try changing the type of the left hand side, or casting the right hand side to '(dynamic, dart.core::int) → dart.async::Future<dart.io::RawSocket>'.
      SocketFactory socketFactory: defaultSocketFactory,
```