### PR TITLE
Remove user connection.options file and add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ out
 javaspeed/build
 javaspeed/gradle
 javaspeed/.gradle
+connection.options

--- a/connection.options
+++ b/connection.options
@@ -1,7 +1,0 @@
-# create connection.options to define how the integration tests connect
-user=root
-#defaults to 3306
-port=3306
-db=sqljockeytest
-#defaults to localhost
-host=localhost


### PR DESCRIPTION
Remove user connection.options file and add to .gitignore, already have connection.options.example in repository.

Avoids conflict when merging with custom options set for test cases.