### PR TITLE
proposing a closeable prepare

### DIFF
--- a/lib/internal/connection/impl.dart
+++ b/lib/internal/connection/impl.dart
@@ -11,19 +11,6 @@ import 'package:sqljocky5/internal/prepared_statement_handler/prepare_handler.da
 import 'package:sqljocky5/internal/query_handler/query_stream_handler.dart';
 import 'package:sqljocky5/internal/comm/comm.dart';
 
-class PrepareResult {
-  final Comm _socket;
-  final Duration _timeout;
-  PreparedQuery query;
-  StreamedResults results;
-  PrepareResult(this._socket, this._timeout, this.query, results);
-
-  close() async {
-    await _socket.execHandlerNoResponse(
-        CloseStatementHandler(query.statementHandlerId), _timeout);
-  }
-}
-
 class MySqlConnectionImpl implements MySqlConnection {
   final Duration _timeout;
 

--- a/lib/internal/connection/impl.dart
+++ b/lib/internal/connection/impl.dart
@@ -146,11 +146,8 @@ class PreparedImpl implements Prepared {
   }
 
   @override
-  Future<void> close() async {
+  Future<void> deallocate() async {
     await _socket.execHandlerNoResponse(
         CloseStatementHandler(_query.statementHandlerId), _timeout);
   }
-
-  @override
-  Future<void> deallocate() => throw UnimplementedError();
 }

--- a/lib/public/connection/connection.dart
+++ b/lib/public/connection/connection.dart
@@ -83,8 +83,6 @@ abstract class Prepared {
   /// Executes the statement multiple times with the given [values].
   Stream<StreamedResults> executeAll(Iterable<Iterable> values);
 
-  Future<void> close();
-
   /// Releases the prepared statement.
   Future<void> deallocate();
 }

--- a/lib/public/connection/connection.dart
+++ b/lib/public/connection/connection.dart
@@ -83,6 +83,8 @@ abstract class Prepared {
   /// Executes the statement multiple times with the given [values].
   Stream<StreamedResults> executeAll(Iterable<Iterable> values);
 
+  Future<void> close();
+
   /// Releases the prepared statement.
   Future<void> deallocate();
 }


### PR DESCRIPTION
preparing a closable prepare to allow  caller to close the prepared statement to avoid hitting mysql prepare statement limit
example:
```
Prepared prepared = await adapter.prepare("select * from users where id=?");
Results result = await (await prepared.execute([5])).deStream();
if (result.length < 1) {
  prepared.deallocate();
  return null;
}
// parsing code...
logger.fine("mapped ${result.first}");
// more code here...
prepared.deallocate();
```